### PR TITLE
Fix hydra plugin to 0.9.0rc2

### DIFF
--- a/hydra/requirements.txt
+++ b/hydra/requirements.txt
@@ -1,1 +1,1 @@
-hydra-optuna-sweeper
+hydra-optuna-sweeper==0.9.0rc2


### PR DESCRIPTION
Fix the error in [CI jobs](https://github.com/toshihikoyanase/optuna-examples/runs/2519464256?check_suite_focus=true).

The error message is as follows: 
```console
Key 'optuna_config' not in 'OptunaSweeperConf'
	full_key: hydra.sweeper.optuna_config
	reference_type=Optional[OptunaSweeperConf]
	object_type=OptunaSweeperConf

Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.
```
This is due to the update of hydra plugin (v1.1.0.dev1), and this PR fixes the version of plugin.
The config file will be updated in a new PR.