### PR TITLE
Update `hydra` example for `hydra-core` v1.2.0

### DIFF
--- a/hydra/conf/config.yaml
+++ b/hydra/conf/config.yaml
@@ -11,21 +11,10 @@ hydra:
     storage: null
     n_trials: 20
     n_jobs: 1
-
-    search_space:
-      x:
-        type: float
-        low: -5.5
-        high: 5.5
-        step: 0.5
-      y:
-        type: categorical
-        choices: [-5, 0, 5]
-      z:
-        type: int
-        low: 1
-        high: 32
-        log: true
+    params:
+      x: range(-5.5, 5.5, step=0.5)
+      y: choice(-5 ,0 ,5)
+      z: tag(log, int(interval(1, 32)))
 
 x: 1
 y: 1

--- a/hydra/requirements.txt
+++ b/hydra/requirements.txt
@@ -1,1 +1,1 @@
-hydra-optuna-sweeper
+hydra-optuna-sweeper>=1.2.0

--- a/hydra/simple.py
+++ b/hydra/simple.py
@@ -16,7 +16,7 @@ from omegaconf import DictConfig
 import hydra
 
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(version_base=None, config_path="conf", config_name="config")
 def objective(cfg: DictConfig) -> float:
     x: float = cfg.x
     y: float = cfg.y


### PR DESCRIPTION
## Motivation

CI failed due to the release of `hydra-core=1.2.0` and `hydra-optuna-sweeper=1.2.0` .
hydra v1.2.0 seems to replace `search_space` with `params` to use the same syntax in both config files and command-line options.
https://hydra.cc/docs/plugins/optuna_sweeper/


## Description of the changes
- replace `search_space` with `params`
- add `version_base=None` to suppress warnings
- add lower bound of `hydra-optuna-sweeper` version